### PR TITLE
Resolve $HOME in profile.d at runtime rather than during the build

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -20,12 +20,13 @@ unset GIT_DIR
 write_profile() {
   local root_dir="$1"
   # This assumes that Heroku initially looks for profiles at the $HOME folder, which it does
-  local subdir="$HOME/$2"
+  local subdir="$2"
   mkdir -p $root_dir/.profile.d
 
   # Set the home directory to be the subdir and source all profiles that
   # were placed here by the invoked buildpack
-  echo "export HOME=$subdir && for f in $subdir/.profile.d/*; do source \$f; done" > $root_dir/.profile.d/heroku-subdir-init.sh
+  # The $HOME variable must be escaped, so that its value is resolved at runtime and not now.
+  echo "export HOME=\"\$HOME/$subdir\" && for f in \"$subdir/.profile.d/\"*; do source \"\$f\"; done" > "$root_dir/.profile.d/heroku-subdir-init.sh"
 }
 
 


### PR DESCRIPTION
Hi! I'm on the team that maintains Heroku's build system.

In the next week or so we plan on changing the value for `$HOME` at build time as part of moving where the build occurs, however this buildpack was found to not be compatible with this change, which will be fixed by this PR.

---

Previously the value for `$HOME` was resolved at build time, meaning its actual value during the build is hardcoded in the `.profile.d/` script, rather than just the variable name.

Whilst the value for `$HOME` is currently the same at both build-time and run-time (both `/app`), the build-time value (only) is due to change in the future to a path under `/tmp`.

By escaping the dollar sign, the variable `$HOME` is now resolved at runtime, making the buildpack compatible with this future change.